### PR TITLE
fix the bug when the page index is bigger than the subview count

### DIFF
--- a/UIScrollViewSlidingPages/Source/TTScrollSlidingPagesController.m
+++ b/UIScrollViewSlidingPages/Source/TTScrollSlidingPagesController.m
@@ -334,7 +334,7 @@
     while (currentXPosition <= bottomScrollView.contentOffset.x && currentXPosition < bottomScrollView.contentSize.width){
         currentXPosition += [self getWidthOfPage:page];
         
-        if (currentXPosition <= bottomScrollView.contentOffset.x){
+        if (currentXPosition <= bottomScrollView.contentOffset.x && page < [bottomScrollView.subviews count]-1){
             page++;
         }
     }


### PR DESCRIPTION
If a user is at the last page, and try to scroll all the way to the left, then the app will crash. It is because in the getCurrentDisplayedPage method, the page index can be bigger than the subview count, thus causing crash. Fixed by checking the page number before incrementing it. 