### PR TITLE
Prevent vertical scrolling

### DIFF
--- a/UIScrollViewSlidingPages/Source/TTScrollSlidingPagesController.m
+++ b/UIScrollViewSlidingPages/Source/TTScrollSlidingPagesController.m
@@ -550,6 +550,9 @@
     
     if (scrollView == topScrollView){
         //translate the top scroll to the bottom scroll
+
+        //prevent vertical scrolling
+        [scrollView setContentOffset:CGPointMake(scrollView.contentOffset.x, 0)];
         
         //get the page number of the scroll item (e.g third header = 3rd page).
         int pageNumber =  [self getTopScrollViewPageForXPosition:topScrollView.contentOffset.x];


### PR DESCRIPTION
Add a call to `setContentOffset` to ensure Y-value remains `0`; closes #23.